### PR TITLE
Supports ttl constructor option with external redis instances

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -18,7 +18,11 @@ const redisStore = (...args) => {
     redisCache = new Redis(...args);
   }
 
-  const storeArgs = redisCache.options;
+  const storeArgs = {
+    ...redisCache.options,
+    ttl: args.length > 0 ? args[0].ttl : undefined
+  };
+
 
   let self = {
     name: 'redis',

--- a/index.js
+++ b/index.js
@@ -16,7 +16,11 @@ const redisStore = (...args) => {
     redisCache = new Redis(...args);
   }
 
-  const storeArgs = redisCache.options;
+  const storeArgs = {
+    ...redisCache.options,
+    ttl: args.length > 0 ? args[0].ttl : undefined
+  };
+
 
   let self = {
     name: 'redis',

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -132,6 +132,28 @@ describe('set', () => {
     });
   });
 
+  it('should respect the ttl option when supplied an external redis instance', (done) => {
+    const externalRedisInstanceCache = cacheManager.caching({
+      store: redisStore,
+      redisInstance: new Redis({
+        host: config.host,
+        port: config.port,
+        password: config.password,
+        db: config.db,
+      }),
+      ttl: 123
+    });
+
+    externalRedisInstanceCache.set('foo', 'bar', (err) => {
+      expect(err).toEqual(null);
+      redisCache.ttl('foo', (err, ttl) => {
+        expect(err).toEqual(null);
+        expect(ttl).toEqual(123);
+        done();
+      });
+    });
+  });
+
   it('should not be able to store a null value (not cacheable)', (done) => {
     redisCache.set('foo2', null, (err) => {
       if (err) {


### PR DESCRIPTION
This addresses the issue in #14 